### PR TITLE
Load a better quality image for a child of the group

### DIFF
--- a/src/app/visit/visit.component.ts
+++ b/src/app/visit/visit.component.ts
@@ -175,10 +175,28 @@ export class VisitComponent implements OnInit, AfterViewInit, OnDestroy {
                 this.visitPoints.push(row);
                 this.visitService.getBetterQualityOfImage(row.code).subscribe({
                     next: (data) => {
-                        const imageIndex = this.dataSource.data.findIndex(
-                            (value) => value.code === data.code,
+                        let childIndex = -1;
+                        const index = this.dataSource.data.findIndex(
+                            (value) => {
+                                if ((value as any).child) {
+                                    childIndex = (value as any).child.findIndex(
+                                        (ch) => ch.code === data.code,
+                                    );
+
+                                    if (childIndex !== -1) {
+                                        return true;
+                                    }
+                                }
+                                return value.code === data.code;
+                            },
                         );
-                        this.dataSource.data[imageIndex].image = data.image;
+                        if (childIndex !== -1) {
+                            (this.dataSource.data[index] as any).child[
+                                childIndex
+                            ].image = data.image;
+                        } else {
+                            this.dataSource.data[index].image = data.image;
+                        }
                     },
                     error: (err) => {
                         console.log(err);


### PR DESCRIPTION
Trying to load a better quality of an image for any of the child of a group was creating an error as we were trying to set an image on a group not on it's child. Now it is fixed and error doesn't show anymore.

| now | before | 
| --- | --- | 
| ![brave_JBEwcU2riU](https://github.com/Johngtka/BioMagnetic-app/assets/11686968/37806293-0d2b-4b1f-8a2c-525da10ba6f9) | ![f6hdouQGvg](https://github.com/Johngtka/BioMagnetic-app/assets/11686968/4d9252e3-72ea-485b-a14c-6bae3c3e4ebe) |

